### PR TITLE
Update `bindgen` to `0.31.3`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT/Apache-2.0"
 build = "build.rs"
 
 [build-dependencies]
-bindgen = "^0.30.0"
+bindgen = "^0.31.3"
 
 [features]
 # Enables SDK 2.0 features

--- a/build.rs
+++ b/build.rs
@@ -33,9 +33,6 @@ fn configure_bindings() -> bindgen::Builder {
         .header("src/combined.h")
         // Tests can't run because the XPLM stub library is not found
         .layout_tests(false)
-        // Interpret all XPLM enum as constants
-        // (like the headers)
-        .constified_enum("*")
 }
 
 /// Returns true if a feature with a provided name is enabled in the current build.


### PR DESCRIPTION
The `constified_enum` translation for C `enum`s is the default now, and does not need to be explicitly specified.

*Note: I wasn't able to get `cargo test` to succeed with or without this change, so I am not 100% sure everything is gravy after these changes.*